### PR TITLE
Recover after Proxy Authentication Required error.

### DIFF
--- a/src/main/java/org/kpax/winfoom/proxy/TunnelConnection.java
+++ b/src/main/java/org/kpax/winfoom/proxy/TunnelConnection.java
@@ -181,6 +181,7 @@ public class TunnelConnection {
             }
             logger.debug("Close tunnel connection");
             InputOutputs.close(connection);
+            this.proxyAuthState = new AuthState(); //Work-around to recover after 407 response
             throw new TunnelRefusedException("CONNECT refused by proxy: " + response.getStatusLine(), response);
         }
 


### PR DESCRIPTION
First of all thank you for your project. It helped me a lot when I recently was forced to work with NTLM.

Though it was working charmingly when I tested everything, I found that I got HTML 407 codes form the NTLM server when I run scripts making heavy usage of HTTPS downloads for a few minutes.

Once I got the first HTML 407 code, the situation seemed persistent, meaning that all successive requests failed, and also after waiting a few minutes, no further HTTPS requests passed.

This pull request contains a quick work-around which solved the problem for me. It was more a hunch than an understanding of the problem. So please consider it more an additional hint where the problem might be than a PR. Unfortunately I am not firm with the HTTP/NTML protocol. Hence I would need more time for an analysis than I currently have.