### PR TITLE
Starting in background

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ The available settings:
 |socket.soTimeout|The timeout for read/write through socket channel (seconds)|Integer|30|
 |socket.connectTimeout|The timeout for socket connect (seconds)|Integer|10|
 |useSystemProperties|Whether to use the environment properties when configuring a HTTP client builder|Boolean|false|
+|startingInBackground|Whether to start proxy automatically and put application top the background on startup|Boolean|false|
 
 ### Authentication
 * For HTTP proxy type, Winfoom uses the current Windows user credentials to authenticate to the remote proxy.

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The available settings:
 |socket.soTimeout|The timeout for read/write through socket channel (seconds)|Integer|30|
 |socket.connectTimeout|The timeout for socket connect (seconds)|Integer|10|
 |useSystemProperties|Whether to use the environment properties when configuring a HTTP client builder|Boolean|false|
-|startingInBackground|Whether to start proxy automatically and put application top the background on startup|Boolean|false|
+|startingInBackground|Whether to start proxy automatically and put application to the background on startup|Boolean|false|
 
 ### Authentication
 * For HTTP proxy type, Winfoom uses the current Windows user credentials to authenticate to the remote proxy.

--- a/src/main/java/org/kpax/winfoom/FoomApplication.java
+++ b/src/main/java/org/kpax/winfoom/FoomApplication.java
@@ -70,10 +70,7 @@ public class FoomApplication {
         final AppFrame frame = applicationContext.getBean(AppFrame.class);
         EventQueue.invokeLater(() -> {
             try {
-                frame.pack();
-                frame.setLocationRelativeTo(null);
-                frame.setVisible(true);
-                frame.focusOnStartButton();
+                frame.activate();
             } catch (Exception e) {
                 logger.error("GUI error", e);
                 SwingUtils.showErrorMessage(null, "Failed to load the graphical interface." +

--- a/src/main/java/org/kpax/winfoom/config/SystemConfig.java
+++ b/src/main/java/org/kpax/winfoom/config/SystemConfig.java
@@ -99,6 +99,12 @@ public class SystemConfig {
      */
     @Value("${useSystemProperties:false}")
     private boolean useSystemProperties;
+    
+    /**
+     * Whether to start automatically in background
+     */
+    @Value("${startingInBackground:false}")
+    private boolean startingInBackground;    
 
     public Integer getMaxConnectionsPerRoute() {
         return maxConnectionsPerRoute;
@@ -136,6 +142,10 @@ public class SystemConfig {
         return socketConnectTimeout;
     }
 
+    public boolean isStartingInBackgound() {
+        return startingInBackground;
+    }
+    
     public RequestConfig.Builder applyConfig(final RequestConfig.Builder configBuilder) {
         return configBuilder.setConnectTimeout(socketConnectTimeout * 1000)
                 .setConnectionRequestTimeout(socketSoTimeout * 1000)


### PR DESCRIPTION
I use WinFoom a lot and wanted it to start the proxy automatically in the background / as tray icon.
Since WinFoom is nicely light (no installer required, ...) and flexible, I did not want to add hack Windows registry to auto-start. I just added a corresponding system property.
Furthermore I found it helpful to bring the application back into foreground in case any errors popups occur, since otherwise it is not clear to the user to which application the popups belong.

I seldomly do GUI programming, so please have a look...

- I think the missing [removal of tray icon](https://github.com/ecovaci/winfoom/compare/master...fvgh:starting_in_background?expand=1#diff-1bc9424ae681458e88bcddf3a218618fR121) was a bug in the original implementation (at least I got a few exceptions running the original code)
- According to my understanding there are [no implicit state changes](https://github.com/ecovaci/winfoom/compare/master...fvgh:starting_in_background?expand=1#diff-1bc9424ae681458e88bcddf3a218618fR135) when minimizing/maximizing the window.