### PR TITLE
launch - Use currentDir

### DIFF
--- a/assets/batch/launch.bat
+++ b/assets/batch/launch.bat
@@ -16,6 +16,10 @@
 
 setlocal EnableDelayedExpansion
 
+set currentFileDir=%~dp0
+:: removing the trailing backslash
+set currentFileDir=%currentFileDir:~0,-1%
+
 if "%1"=="--help" goto usage
 
 set ARGS=-server -XX:+UseG1GC -XX:MaxHeapFreeRatio=30 -XX:MinHeapFreeRatio=10
@@ -36,7 +40,7 @@ for %%a in (%*) do (
 )
 
 if exist out.log (
-del /F out.log
+	del /F out.log
 )
 
 if exist out.log (
@@ -44,13 +48,13 @@ if exist out.log (
 	exit /B 2
 )
 
-if exist .\jdk\bin\javaw.exe (
-set JAVA_EXE=.\jdk\bin\javaw
+if exist %currentFileDir%\jdk\bin\javaw.exe (
+	set JAVA_EXE=%currentFileDir%\jdk\bin\javaw
 ) else (
-set JAVA_EXE=javaw
+	set JAVA_EXE=javaw
 )
 
-start /B %JAVA_EXE% %ARGS% -cp . -jar winfoom.jar > out.log 2>&1
+start /B %JAVA_EXE% %ARGS% -jar %currentFileDir%\winfoom.jar > out.log 2>&1
 
 @echo You can check the application log with the command: type "%userprofile%\.winfoom\logs\winfoom.log"
 @echo If application is not launched in GUI mode, use foomcli script for management

--- a/assets/batch/launchGui.bat
+++ b/assets/batch/launchGui.bat
@@ -16,6 +16,10 @@
 
 setlocal EnableExtensions
 
+set currentFileDir=%~dp0
+:: removing the trailing backslash
+set currentFileDir=%currentFileDir:~0,-1%
+
 set ARGS=-server -XX:+UseG1GC -XX:MaxHeapFreeRatio=30 -XX:MinHeapFreeRatio=10 -Dswing.aatext=true -Dspring.profiles.active=gui
 
 if defined FOOM_ARGS set ARGS=%FOOM_ARGS% %ARGS%
@@ -29,13 +33,13 @@ if exist out.log (
 	exit /B 2
 )
 
-if exist .\jdk\bin\javaw.exe (
-set JAVA_EXE=.\jdk\bin\javaw
+if exist %currentFileDir%\jdk\bin\javaw.exe (
+set JAVA_EXE=%currentFileDir%\jdk\bin\javaw
 ) else (
 set JAVA_EXE=javaw
 )
 
-start /B %JAVA_EXE% %ARGS% -cp . -jar winfoom.jar > out.log 2>&1
+start /B %JAVA_EXE% %ARGS% -jar %currentFileDir%\winfoom.jar > out.log 2>&1
 
 exit /B %ERRORLEVEL%
 


### PR DESCRIPTION
I've made some minor improvements in the `launch.bat` and `launchGui.bat` files.

They are using the batch path to find JDK (if present) and `winfoom.jar`.