### PR TITLE
* Add local address and api address

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,9 +150,10 @@ to get the current configuration. You'll get something like:
 
 ```
 {
-"proxyType" : "DIRECT",
-"localPort" : 3129,
-"proxyTestUrl" : "https://example.com"
+  "proxyType" : "DIRECT",
+  "localAddress" : "localhost",
+  "localPort" : 3129,
+  "proxyTestUrl" : "https://example.com"
 }
 ```
 
@@ -168,6 +169,7 @@ Then, executing `foomcli config` again, the output is something like:
   "proxyType" : "HTTP",
   "proxyHost" : "",
   "proxyPort" : 0,
+  "localAddress" : "localhost",
   "localPort" : 3129,
   "proxyTestUrl" : "http://example.com",
   "useCurrentCredentials" : true
@@ -182,11 +184,12 @@ in the same directory, and edit the field's values accordingly:
 
 ```
 {
-"proxyType" : "HTTP",
-"proxyHost" : "192.168.0.105",
-"proxyPort" : 80,
-"localPort" : 3129,
-"proxyTestUrl" : "http://example.com"
+  "proxyType" : "HTTP",
+  "proxyHost" : "192.168.0.105",
+  "proxyPort" : 80,
+  "localAddress" : "localhost",
+  "localPort" : 3129,
+  "proxyTestUrl" : "http://example.com"
 }
 ```
 
@@ -217,6 +220,7 @@ Execute `foomcli config -f http_config.json` again, then `foomcli config` to see
   "proxyPort" : 80,
   "proxyUsername" : null,
   "proxyPassword" : null,
+  "localAddress" : "localhost",
   "localPort" : 3129,
   "proxyTestUrl" : "http://example.com",
   "useCurrentCredentials" : false,
@@ -253,6 +257,7 @@ If the proxy type is PAC, then the output of the `foomcli config` command would 
   "proxyPassword" : "***",
   "proxyPacFileLocation" : "C:\\path_to\\proxy-ntlm-auth.pac",
   "blacklistTimeout" : 30,
+  "localAddress" : "localhost",
   "localPort" : 3129,
   "proxyTestUrl" : "https://example.com",
   "pacHttpAuthProtocol" : "NTLM"
@@ -271,10 +276,11 @@ The output would be something like:
 
 ```
 {
-"autostart" : false,
-"autodetect" : false,
-"appVersion" : "3.0.1",
-"apiPort" : 9999
+  "autostart" : false,
+  "autodetect" : false,
+  "appVersion" : "3.0.1",
+  "apiAddress" : "localhost",
+  "apiPort" : 9999
 }
 ```
 
@@ -282,7 +288,7 @@ Copy the output into a file named, let's say, `settings.json` and modify accordi
 
 ```
 {
-"autostart" : true
+  "autostart" : true
 }
 ```
 
@@ -294,7 +300,7 @@ To load the new values, execute:
 
 then check the new settings with `foomcli settings`
 
-> 👉 Note: If you modify the apiPort then you need to set the variable FOOM_LOCATION. 
+> 👉 Note: If you modify the apiAddress or the apiPort then you need to set the variable FOOM_LOCATION.
 > (For example FOOM_LOCATION=localhost:[your new port])
 
 > 👉 WARNING: All the provided passwords are stored encoded BASE64 without any encryption. 

--- a/src/main/java/org/kpax/winfoom/api/ApiController.java
+++ b/src/main/java/org/kpax/winfoom/api/ApiController.java
@@ -46,6 +46,7 @@ import org.springframework.stereotype.Component;
 import javax.annotation.PostConstruct;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
+import java.net.InetAddress;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
 
@@ -76,7 +77,9 @@ public class ApiController implements AutoCloseable {
     private void init() throws IOException {
         Credentials credentials = new ApiCredentials(proxyConfig.getApiToken());
         log.info("Register API request handlers");
-        apiServer = ServerBootstrap.bootstrap().setListenerPort(proxyConfig.getApiPort()).
+        apiServer = ServerBootstrap.bootstrap().
+                setLocalAddress(InetAddress.getByName(proxyConfig.getApiAddress())).
+                setListenerPort(proxyConfig.getApiPort()).
                 registerHandler("/start",
                         new GenericHttpRequestHandler(credentials, executorService, systemConfig) {
                             @Override

--- a/src/main/java/org/kpax/winfoom/api/dto/ConfigDto.java
+++ b/src/main/java/org/kpax/winfoom/api/dto/ConfigDto.java
@@ -38,6 +38,7 @@ public class ConfigDto {
     private Integer blacklistTimeout;
     private String proxyHost;
     private Integer proxyPort;
+    private String localAddress;
     private Integer localPort;
     private String proxyTestUrl;
 
@@ -54,6 +55,12 @@ public class ConfigDto {
         if (proxyPort != null) {
             if (!HttpUtils.isValidPort(proxyPort)) {
                 throw new InvalidProxySettingsException("Invalid proxyPort, allowed range: 1 - 65535");
+            }
+        }
+
+        if (localAddress != null) {
+            if (!HttpUtils.isValidAddress(localAddress)) {
+                throw new InvalidProxySettingsException("Invalid localAddress, use a locally bound address");
             }
         }
 

--- a/src/main/java/org/kpax/winfoom/api/dto/SettingsDto.java
+++ b/src/main/java/org/kpax/winfoom/api/dto/SettingsDto.java
@@ -27,11 +27,17 @@ import org.kpax.winfoom.util.HttpUtils;
 @ToString
 public class SettingsDto {
 
+    private String apiAddress;
     private Integer apiPort;
     private Boolean autodetect;
     private Boolean autostart;
 
     public void validate() throws InvalidProxySettingsException {
+        if (apiAddress != null) {
+            if (!HttpUtils.isValidAddress(apiAddress)) {
+                throw new InvalidProxySettingsException("Invalid apiAddress, use a locally bound address");
+            }
+        }
         if (apiPort != null) {
             if (!HttpUtils.isValidPort(apiPort)) {
                 throw new InvalidProxySettingsException("Invalid apiPort, allowed range: 1 - 65535");

--- a/src/main/java/org/kpax/winfoom/config/ProxyConfig.java
+++ b/src/main/java/org/kpax/winfoom/config/ProxyConfig.java
@@ -57,13 +57,16 @@ import java.util.Properties;
 @Slf4j
 @JsonPropertyOrder({"proxyType", "proxyHost", "proxyPort", "proxyUsername", "proxyPassword", "proxyStorePassword",
         "proxyPacFileLocation", "blacklistTimeout",
-        "localPort", "proxyTestUrl", "autostart", "autodetect"})
+        "localAddress", "localPort", "proxyTestUrl", "autostart", "autodetect"})
 @Component
 @PropertySource(value = "file:./config/proxy.properties", ignoreResourceNotFound = true)
 public class ProxyConfig {
 
     @Value("${app.version}")
     private String appVersion;
+
+    @Value("${api.address:localhost}")
+    private String apiAddress;
 
     @Value("${api.port:9999}")
     private Integer apiPort;
@@ -77,6 +80,9 @@ public class ProxyConfig {
 
     @Value("${proxy.type:DIRECT}")
     private Type proxyType;
+
+    @Value("${local.address:localhost}")
+    private String localAddress;
 
     @Value("${local.port:3129}")
     private Integer localPort;
@@ -286,6 +292,15 @@ public class ProxyConfig {
 
     public void setLocalPort(Integer localPort) {
         this.localPort = localPort;
+    }
+
+    @JsonView(value = {Views.Common.class})
+    public String getLocalAddress() {
+        return localAddress;
+    }
+
+    public void setLocalAddress(String localAddress) {
+        this.localAddress = localAddress;
     }
 
     @JsonView(value = {Views.Http.class, Views.Socks4.class})
@@ -547,6 +562,15 @@ public class ProxyConfig {
     }
 
     @JsonView(value = {Views.Settings.class})
+    public String getApiAddress() {
+        return apiAddress;
+    }
+
+    public void setApiAddress(String apiAddress) {
+        this.apiAddress = apiAddress;
+    }
+
+    @JsonView(value = {Views.Settings.class})
     public Integer getApiPort() {
         return apiPort;
     }
@@ -581,6 +605,7 @@ public class ProxyConfig {
                 .propertiesBuilder(userProperties);
         Configuration config = propertiesBuilder.getConfiguration();
         setProperty(config, "app.version", appVersion);
+        setProperty(config, "api.address", apiAddress);
         setProperty(config, "api.port", apiPort);
         setProperty(config, "proxy.type", proxyType);
         setProperty(config, "proxy.http.host", proxyHttpHost);
@@ -589,6 +614,7 @@ public class ProxyConfig {
         setProperty(config, "proxy.socks4.port", proxySocks4Port);
         setProperty(config, "proxy.socks5.host", proxySocks5Host);
         setProperty(config, "proxy.socks5.port", proxySocks5Port);
+        setProperty(config, "local.address", localAddress);
         setProperty(config, "local.port", localPort);
         setProperty(config, "proxy.test.url", proxyTestUrl);
         setProperty(config, "proxy.http.username", proxyHttpUsername);

--- a/src/main/java/org/kpax/winfoom/proxy/LocalProxyServer.java
+++ b/src/main/java/org/kpax/winfoom/proxy/LocalProxyServer.java
@@ -24,6 +24,7 @@ import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
 
+import java.net.InetAddress;
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.net.Socket;
@@ -69,7 +70,8 @@ class LocalProxyServer implements StopListener {
         try {
             final ClientConnectionHandler clientConnectionHandler = clientConnectionHandlerSelector.select();
             serverSocket = new ServerSocket(proxyConfig.getLocalPort(),
-                    systemConfig.getServerSocketBacklog());
+                    systemConfig.getServerSocketBacklog(),
+                    InetAddress.getByName(proxyConfig.getLocalAddress()));
             executorService.submit(() -> {
                 while (true) {
                     try {
@@ -101,7 +103,7 @@ class LocalProxyServer implements StopListener {
                     }
                 }
             });
-            log.info("Server started, listening on port: " + proxyConfig.getLocalPort());
+            log.info("Server started, listening on address: " + proxyConfig.getLocalAddress() + " and port: " + proxyConfig.getLocalPort());
         } catch (Exception e) {
             // Cleanup on exception
             close();

--- a/src/main/java/org/kpax/winfoom/proxy/ProxyValidator.java
+++ b/src/main/java/org/kpax/winfoom/proxy/ProxyValidator.java
@@ -49,7 +49,7 @@ public class ProxyValidator {
     public void testProxy() throws IOException, InvalidProxySettingsException {
         try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
             HttpHost target = HttpHost.create(proxyConfig.getProxyTestUrl());
-            HttpHost proxy = new HttpHost("localhost", proxyConfig.getLocalPort());
+            HttpHost proxy = new HttpHost(proxyConfig.getLocalAddress(), proxyConfig.getLocalPort());
             RequestConfig config = RequestConfig.custom()
                     .setProxy(proxy)
                     .setCircularRedirectsAllowed(true)

--- a/src/main/java/org/kpax/winfoom/util/HttpUtils.java
+++ b/src/main/java/org/kpax/winfoom/util/HttpUtils.java
@@ -29,6 +29,7 @@ import org.kpax.winfoom.exception.PacScriptException;
 import org.kpax.winfoom.proxy.ProxyInfo;
 import org.springframework.util.Assert;
 
+import java.net.InetAddress;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -261,6 +262,23 @@ public final class HttpUtils {
         return new BasicStatusLine(protocolVersion, httpCode,
                 StringUtils.isEmpty(reasonPhrase) ?
                         EnglishReasonPhraseCatalog.INSTANCE.getReason(httpCode, Locale.ENGLISH) : reasonPhrase);
+    }
+
+    /**
+     * Validate an address.
+     *
+     * @param addr the address value.
+     * @return {@code true} if the address value is locally bound.
+     */
+    public static boolean isValidAddress(final String addr) {
+        try {
+            InetAddress inetAddr = InetAddress.getByName(addr);
+            if (inetAddr.isAnyLocalAddress() || inetAddr.isLoopbackAddress())
+                return true;
+            return NetworkInterface.getByInetAddress(inetAddr) != null;
+        } catch (Exception e) {
+            return false;
+        }
     }
 
     /**

--- a/src/main/java/org/kpax/winfoom/view/AppFrame.java
+++ b/src/main/java/org/kpax/winfoom/view/AppFrame.java
@@ -208,6 +208,10 @@ public class AppFrame extends JFrame {
         return new JLabel("Proxy port* ");
     }
 
+    private JLabel getLocalAddressLabel() {
+        return new JLabel("Local address* ");
+    }
+
     private JLabel getLocalPortLabel() {
         return new JLabel("Local proxy port* ");
     }
@@ -314,6 +318,13 @@ public class AppFrame extends JFrame {
         proxyPortJSpinner.setToolTipText("The remote proxy port, between 1 and 65535");
         proxyPortJSpinner.addChangeListener(e -> proxyConfig.setProxyPort((Integer) proxyPortJSpinner.getValue()));
         return proxyPortJSpinner;
+    }
+
+    private JTextField getLocalAddressJTextField() {
+        JTextField localAddressJTextField = createTextField(proxyConfig.getLocalAddress());
+        localAddressJTextField.setToolTipText("The ip or domain name of a local interface");
+        localAddressJTextField.getDocument().addDocumentListener((TextChangeListener) (e) -> proxyConfig.setLocalAddress(localAddressJTextField.getText()));
+        return localAddressJTextField;
     }
 
     private JSpinner getLocalPortJSpinner() {
@@ -555,11 +566,13 @@ public class AppFrame extends JFrame {
     private void configureForHttp() {
         labelPanel.add(getProxyHostLabel());
         labelPanel.add(getProxyPortLabel());
+        labelPanel.add(getLocalAddressLabel());
         labelPanel.add(getLocalPortLabel());
         labelPanel.add(getUseSystemCredentialsLabel());
 
         fieldPanel.add(getProxyHostJTextField());
         fieldPanel.add(wrapToPanel(getProxyPortJSpinner()));
+        fieldPanel.add(getLocalAddressJTextField());
         fieldPanel.add(wrapToPanel(getLocalPortJSpinner()));
         fieldPanel.add(getUseSystemCredentialsJCheckBox());
 
@@ -577,16 +590,19 @@ public class AppFrame extends JFrame {
     private void configureForSocks4() {
         labelPanel.add(getProxyHostLabel());
         labelPanel.add(getProxyPortLabel());
+        labelPanel.add(getLocalAddressLabel());
         labelPanel.add(getLocalPortLabel());
 
         fieldPanel.add(getProxyHostJTextField());
         fieldPanel.add(wrapToPanel(getProxyPortJSpinner()));
+        fieldPanel.add(getLocalAddressJTextField());
         fieldPanel.add(wrapToPanel(getLocalPortJSpinner()));
     }
 
     private void configureForPac() {
         labelPanel.add(getPacFileLabel());
         labelPanel.add(getBlacklistTimeoutLabel());
+        labelPanel.add(getLocalAddressLabel());
         labelPanel.add(getLocalPortLabel());
         labelPanel.add(getUsernameLabel(false));
         labelPanel.add(getPasswordLabel(false));
@@ -595,6 +611,7 @@ public class AppFrame extends JFrame {
         fieldPanel.add(getPacFileJTextField());
         fieldPanel.add(wrapToPanel(getBlacklistTimeoutJSpinner(),
                 new JLabel(" (" + ProxyBlacklist.TEMPORAL_UNIT.toString().toLowerCase() + ")")));
+        fieldPanel.add(getLocalAddressJTextField());
         fieldPanel.add(wrapToPanel(getLocalPortJSpinner()));
 
         fieldPanel.add(getPacUsernameTextField());
@@ -607,7 +624,9 @@ public class AppFrame extends JFrame {
 
 
     private void configureForDirect() {
+        labelPanel.add(getLocalAddressLabel());
         labelPanel.add(getLocalPortLabel());
+        fieldPanel.add(getLocalAddressJTextField());
         fieldPanel.add(wrapToPanel(getLocalPortJSpinner()));
     }
 
@@ -616,12 +635,14 @@ public class AppFrame extends JFrame {
         labelPanel.add(getProxyPortLabel());
         labelPanel.add(getUsernameLabel(false));
         labelPanel.add(getPasswordLabel(false));
+        labelPanel.add(getLocalAddressLabel());
         labelPanel.add(getLocalPortLabel());
 
         fieldPanel.add(getProxyHostJTextField());
         fieldPanel.add(wrapToPanel(getProxyPortJSpinner()));
         fieldPanel.add(getSocks5UsernameJTextField());
         fieldPanel.add(getSocks5PasswordField());
+        fieldPanel.add(getLocalAddressJTextField());
         fieldPanel.add(wrapToPanel(getLocalPortJSpinner()));
     }
 
@@ -772,6 +793,11 @@ public class AppFrame extends JFrame {
 
         if (proxyConfig.isAutoConfig() && StringUtils.isBlank(proxyConfig.getProxyPacFileLocation())) {
             SwingUtils.showErrorMessage(this, "Fill in a valid Pac file location");
+            return false;
+        }
+
+        if (StringUtils.isBlank(proxyConfig.getLocalAddress()) || !HttpUtils.isValidAddress(proxyConfig.getLocalAddress())) {
+            SwingUtils.showErrorMessage(this, "Fill in a valid local proxy address that is locally bound");
             return false;
         }
 


### PR DESCRIPTION
Hi Eugen,

In the light of Open Source software, I thought it would be good to give something back to this project.

Winfoom's listeners are currently binding on all available addresses. This can be a security issue, as the proxy can be open to the entire network.

This is not a problem for normal proxy usage. However, when Winfoom is used to access a protected API on an IIS server, the rest of the world is not allowed to do so.

So I have enhanced Winfoom to make the socket listener configurable so that it can be made available only on localhost, for example.

I have also made the API address configurable, so that it can be shielded from the rest of the network as well.

I hope you appreciate my contribution. I'm not a Java guru myself, but I think the enhancement works fine.