### PR TITLE
Switch to virtual threads and bump docker image to java 25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk:11-jre-hotspot
+FROM eclipse-temurin:25-jre-alpine
 
 LABEL description="Basic Proxy Facade for NTLM, Kerberos, SOCKS and Proxy Auto Config file proxies"
 LABEL maintainer="ecovaci"
@@ -7,15 +7,16 @@ RUN mkdir /opt/winfoom
 
 ADD target/winfoom.jar /opt/winfoom/winfoom.jar
 
+RUN apk add --no-cache bash
 ADD docker-entrypoint.sh /opt/winfoom/docker-entrypoint.sh
 
 RUN chmod +x /opt/winfoom/docker-entrypoint.sh
 
 EXPOSE 3129 9999
 
-RUN groupadd -r winfoom && useradd -r -g winfoom winfoom
+RUN addgroup -S winfoom && adduser -S -g winfoom winfoom
 
-RUN mkdir /data && chown winfoom:winfoom /data
+RUN mkdir /data && chown winfoom:winfoom /data && chown -R winfoom:winfoom /opt/winfoom
 
 USER winfoom
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ An example of such a facade for NTLM proxies is [CNTLM](http://cntlm.sourceforge
 ## Download Winfoom
 ### Download prepackaged
 To try out Winfoom without needing to download the source and package it, check out the [releases](https://github.com/ecovaci/winfoom/releases) for a prepackaged `winfoom-*.zip`.
-Winfoom is a Java application and requires a Java Runtime Environment (at least v11).
+Winfoom is a Java application and requires a Java Runtime Environment (at least v25).
 
 If it is not already installed on your system, you can download it from [AdoptOpenJDK](https://adoptopenjdk.net/) or, 
 on Linux systems, use your package manager.
@@ -38,7 +38,7 @@ to your system architecture, unzip it in the Winfoom directory and rename it to 
 
 ### Build from source code
 If you decide to build the executable *jar* file from the source code, you would need these prerequisites:
-* Java JDK 17(+)
+* Java JDK 25(+)
 * Maven 3.x version (optional)
 
 First download  the source code from [releases](https://github.com/ecovaci/winfoom/releases) and unzip it.

--- a/src/main/java/org/kpax/winfoom/proxy/ProxyExecutorService.java
+++ b/src/main/java/org/kpax/winfoom/proxy/ProxyExecutorService.java
@@ -21,7 +21,6 @@ import org.springframework.stereotype.Component;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.*;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * A wrapper for {@link ThreadPoolExecutor} that forbids {@link #shutdown()}, {@link #shutdownNow()}
@@ -32,13 +31,16 @@ import java.util.concurrent.atomic.AtomicInteger;
 @Component
 public class ProxyExecutorService implements ExecutorService, StopListener {
 
-    private final SingletonSupplier<ThreadPoolExecutor> threadPoolSupplier;
+    private final SingletonSupplier<ExecutorService> threadPoolSupplier;
 
     public ProxyExecutorService() {
         this.threadPoolSupplier =
-                new SingletonSupplier<>(() -> new ThreadPoolExecutor(0, Integer.MAX_VALUE,
-                        60L, TimeUnit.SECONDS, new SynchronousQueue<>(),
-                        new DefaultThreadFactory()));
+                new SingletonSupplier<>(() -> Executors.newThreadPerTaskExecutor(
+                        Thread
+                                .ofVirtual()
+                                .name("virtual-thread-", 0L)
+                                .factory()
+                ));
     }
 
     public void execute(Runnable task) {
@@ -112,36 +114,5 @@ public class ProxyExecutorService implements ExecutorService, StopListener {
     public void onStop() {
         log.debug("Reset the proxy executor service");
         threadPoolSupplier.reset(ExecutorService::shutdownNow);
-    }
-
-    public static class DefaultThreadFactory implements ThreadFactory {
-        private static final AtomicInteger poolNumber = new AtomicInteger(1);
-        private final ThreadGroup group;
-        private final AtomicInteger threadNumber = new AtomicInteger(1);
-        private final String namePrefix;
-
-        public DefaultThreadFactory() {
-            group = Thread.currentThread().getThreadGroup();
-            namePrefix = "pool-" +
-                    poolNumber.getAndIncrement() +
-                    "-thread-";
-        }
-
-        @Override
-        public Thread newThread(Runnable runnable) {
-            Thread thread = new Thread(group, runnable,
-                    namePrefix + threadNumber.getAndIncrement(),
-                    0);
-
-            // Make sure all threads are daemons!
-            if (!thread.isDaemon()) {
-                thread.setDaemon(true);
-            }
-
-            if (thread.getPriority() != Thread.NORM_PRIORITY) {
-                thread.setPriority(Thread.NORM_PRIORITY);
-            }
-            return thread;
-        }
     }
 }


### PR DESCRIPTION
Summary of changes:

* ~~Upgrade from Spring Boot 2 to Spring Boot 3~~ (no longer required after rebase)
* ~~Upgrade all dependencies to latest~~ (no longer required after rebase)
* Switch from adoptopenjdk to temurin (temurin is the new adoptium which was the new adoptopenjdk) EDIT: this is mostly just cleanup following the java 25 update
* Use alpine ~~21~~ 25 for docker image EDIT: this is mostly just cleanup following the java 25 update
* ~~Build a multi-release Jar~~ (no longer required after rebase due to java 25 update)
* Use virtual threads ~~when running on Java 21 or higher~~ (always, because we're now on java 25)

~~Breaking Changes:~~

* ~~The minimum Java version required to run winfoom is increased from Java 11 to Java 17 (due to Spring Boot 3 upgrade)~~
* ~~The minimum Java version required to _build_ winfoom is increased from Java 11 to Java 21 (due to virtual thread support)~~

EDIT: this PR has been heavily rebased. The below comments are still useful from a historical standpoint, but since winfoom has already been moved to Java 25 I can't say for certain whether the improvement in resource utilization will be as drastic as it was between Java 17 with platform threads vs Java 21 with virtual threads (because presumably some of those improvements could have been due to newer jdk versions rather than the switch from platform threads to virtual threads)

~~Comments:~~

~~I've tested this locally on temurin 17, temurin 21, and graalvm 21 (simply changing `JAVA_HOME` when launching the gui), and verified it's working by connecting to the app using jconsole. On Java 17, I see threads named `pool-x-thread-y`. On Java 21, I see `ForkJoinPool` threads instead. In both cases, some basic smoke testing (i.e. `curl https://google.com`) is working through winfoom.~~

~~Unfortunately there's been a bit more refactoring required to support the MRJar than I'd like (i.e. introducing a new package, `org.kpax.winfoom.proxy.concurrent`). There was a lot of trial and error with the multi-release JAR before I figured out that spring boot repackaging doesn't play nicely with importing classes from dependencies in a multi-release jar. Hence why there are no lombok annotations, logging, etc in the new package (I would really have liked to use an slf4j logger here to say whether we are using a thread pool or virtual threads, but alas... it was not meant to be)~~